### PR TITLE
Implement unauthenticated gallery spec

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import ImagePreview from "@/components/ImagePreview";
+import PublicGallery from "@/components/PublicGallery";
 import { Button } from "@/components/ui/button";
 import Webcam from "@/components/Webcam";
 import { api } from "@/convex/_generated/api";
@@ -44,6 +45,12 @@ export default function Home() {
                   upload images and watch as everyday items come to life with whimsical anime charm!
                 </p>
               </div>
+              
+              {/* Public gallery showcase */}
+              <div className="w-full max-w-7xl">
+                <PublicGallery />
+              </div>
+
               <SignInButton>
                 <Button className="btn-primary px-12 py-4 text-lg font-medium rounded-2xl shadow-lg hover:shadow-xl transition-all duration-200">
                   Start Creating

--- a/components/AdminModerationDashboard.tsx
+++ b/components/AdminModerationDashboard.tsx
@@ -1,0 +1,170 @@
+"use client";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+import { useState } from "react";
+import { Button } from "./ui/button";
+import Image from "next/image";
+
+export default function AdminModerationDashboard() {
+  const [paginationOpts, setPaginationOpts] = useState({
+    numItems: 20,
+    cursor: null,
+  });
+
+  const featuredImages = useQuery(api.admin.getAdminFeaturedImages, { paginationOpts });
+  const disableImage = useMutation(api.admin.disableFeaturedImage);
+  const enableImage = useMutation(api.admin.enableFeaturedImage);
+  const [disableReason, setDisableReason] = useState("");
+  const [selectedImageId, setSelectedImageId] = useState<Id<"images"> | null>(null);
+
+  const handleDisableImage = async (imageId: Id<"images">, reason: string) => {
+    try {
+      await disableImage({ imageId, reason });
+      setSelectedImageId(null);
+      setDisableReason("");
+    } catch (error) {
+      console.error("Failed to disable image:", error);
+    }
+  };
+
+  const handleEnableImage = async (imageId: Id<"images">) => {
+    try {
+      await enableImage({ imageId });
+    } catch (error) {
+      console.error("Failed to enable image:", error);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center space-y-4">
+        <h2 className="text-2xl font-semibold">Featured Images Moderation</h2>
+        <p className="text-muted-foreground">
+          Review and moderate featured images in the public gallery
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {featuredImages?.page.map((image) => (
+          <div key={image._id} className="group">
+            <div className={`bg-card border transition-all duration-200 overflow-hidden rounded-xl shadow-sm ${
+              image.isDisabledByAdmin 
+                ? "border-red-500 bg-red-50 dark:bg-red-900/20" 
+                : "border-border/30 hover:border-border hover:shadow-md"
+            }`}>
+              <div className="aspect-square relative">
+                <Image
+                  src={image.url}
+                  alt="Featured transformation"
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
+                />
+
+                {/* Status indicator */}
+                <div className="absolute top-2 left-2">
+                  {image.isDisabledByAdmin ? (
+                    <div className="bg-red-500 text-white text-xs px-2 py-1 rounded-full">
+                      Disabled
+                    </div>
+                  ) : (
+                    <div className="bg-green-500 text-white text-xs px-2 py-1 rounded-full">
+                      Live
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="p-4 space-y-3">
+                <div className="text-xs text-muted-foreground">
+                  User: {image.userId || "Unknown"}
+                </div>
+                
+                {image.isDisabledByAdmin && image.disabledByAdminReason && (
+                  <div className="text-xs text-red-600 bg-red-50 dark:bg-red-900/20 p-2 rounded">
+                    <strong>Disabled:</strong> {image.disabledByAdminReason}
+                  </div>
+                )}
+
+                <div className="flex gap-2">
+                  {image.isDisabledByAdmin ? (
+                    <Button
+                      onClick={() => handleEnableImage(image._id)}
+                      variant="outline"
+                      size="sm"
+                      className="text-green-600 border-green-600 hover:bg-green-50"
+                    >
+                      Re-enable
+                    </Button>
+                  ) : (
+                    <Button
+                      onClick={() => setSelectedImageId(image._id)}
+                      variant="outline"
+                      size="sm"
+                      className="text-red-600 border-red-600 hover:bg-red-50"
+                    >
+                      Disable
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Disable Image Modal */}
+      {selectedImageId && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full space-y-4">
+            <h3 className="text-lg font-semibold">Disable Featured Image</h3>
+            <p className="text-sm text-muted-foreground">
+              This will remove the image from the public gallery. Please provide a reason:
+            </p>
+            <textarea
+              value={disableReason}
+              onChange={(e) => setDisableReason(e.target.value)}
+              placeholder="Reason for disabling (e.g., inappropriate content, quality issues)"
+              className="w-full p-3 border rounded-md"
+              rows={3}
+            />
+            <div className="flex gap-2 justify-end">
+              <Button
+                onClick={() => {
+                  setSelectedImageId(null);
+                  setDisableReason("");
+                }}
+                variant="ghost"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={() => selectedImageId && handleDisableImage(selectedImageId, disableReason)}
+                disabled={!disableReason.trim()}
+                variant="destructive"
+              >
+                Disable Image
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Load More */}
+      {featuredImages?.continueCursor && (
+        <div className="flex justify-center">
+          <Button
+            onClick={() => setPaginationOpts(prev => ({
+              numItems: 20,
+              cursor: featuredImages.continueCursor,
+            }))}
+            variant="ghost"
+          >
+            Load More Images
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/PublicGallery.tsx
+++ b/components/PublicGallery.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { useState, useMemo } from "react";
+import Image from "next/image";
+import { Button } from "./ui/button";
+
+// Same type inference pattern as ImagePreview.tsx
+type PublicImageFromQuery = NonNullable<
+  ReturnType<typeof useQuery<typeof api.images.getPublicGallery>>
+>;
+
+export default function PublicGallery() {
+  const [paginationOpts, setPaginationOpts] = useState({
+    numItems: 16, // Same page size as existing gallery
+    cursor: null,
+  });
+
+  const galleryResult = useQuery(api.images.getPublicGallery, { paginationOpts });
+
+  // Same memoization pattern from main page
+  const images = useMemo(() => galleryResult?.page || [], [galleryResult?.page]);
+
+  // Same early return pattern
+  if (images.length === 0 && galleryResult === undefined) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="w-6 h-6 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  // Show empty state if no featured images exist yet
+  if (images.length === 0 && galleryResult !== undefined) {
+    return (
+      <div className="text-center space-y-4 py-12">
+        <div className="text-muted-foreground">
+          <svg className="w-12 h-12 mx-auto mb-4 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+          </svg>
+        </div>
+        <h3 className="text-lg font-medium">Gallery Coming Soon</h3>
+        <p className="text-muted-foreground max-w-md mx-auto">
+          Our community is creating amazing transformations! Featured examples will appear here soon.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center space-y-4">
+        <h2 className="text-2xl font-semibold">See the magic in action</h2>
+        <p className="text-muted-foreground max-w-2xl mx-auto">
+          Real transformations created by our community. Your photos could look this amazing too.
+        </p>
+      </div>
+
+      {/* Exact same grid layout as ImagePreview component */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {images.map((image) => (
+          <div key={image._id} className="group">
+            {/* Same card styling as ImagePreview */}
+            <div className="bg-card border border-border/30 hover:border-border transition-all duration-200 overflow-hidden rounded-xl shadow-sm hover:shadow-md">
+              <div className="aspect-square relative">
+                <Image
+                  src={image.url}
+                  alt="Anime transformation example"
+                  fill
+                  className="object-cover transition-all duration-300 group-hover:scale-[1.02]"
+                  unoptimized={true} // Same as existing component
+                  sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
+                  // Same error handling pattern as ImagePreview
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.style.display = "none";
+                    const parent = target.parentElement;
+                    if (parent) {
+                      parent.innerHTML = `
+                        <div class="flex items-center justify-center h-full text-muted-foreground bg-muted/30">
+                          <div class="text-center">
+                            <svg class="w-8 h-8 mx-auto mb-2 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                            </svg>
+                            <div class="text-xs opacity-50">Unable to load</div>
+                          </div>
+                        </div>
+                      `;
+                    }
+                  }}
+                />
+
+                {/* Featured indicator */}
+                <div className="absolute top-2 right-2 bg-gradient-to-r from-purple-500 to-blue-500 text-white text-xs px-2 py-1 rounded-full">
+                  ✨ Featured
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Same load more pattern as ImagePreview */}
+      {galleryResult?.continueCursor && !galleryResult.isDone && (
+        <div className="flex items-center justify-center py-8">
+          <Button
+            onClick={() => setPaginationOpts(prev => ({
+              numItems: 16,
+              cursor: galleryResult.continueCursor,
+            }))}
+            variant="ghost"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Show more examples
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -1,0 +1,69 @@
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { assertAdmin } from "./lib/auth";
+import { mapImagesToUrls } from "./lib/images";
+import { PaginatedAdminGalleryValidator } from "./lib/validators";
+
+export const disableFeaturedImage = mutation({
+  args: {
+    imageId: v.id("images"),
+    reason: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await assertAdmin(ctx); // DRY auth check
+    
+    // Same patch pattern as existing updateShareSettings
+    await ctx.db.patch(args.imageId, {
+      isDisabledByAdmin: true,
+      disabledByAdminAt: Date.now(),
+      disabledByAdminReason: args.reason,
+    });
+    return null;
+  },
+});
+
+export const enableFeaturedImage = mutation({
+  args: {
+    imageId: v.id("images"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await assertAdmin(ctx); // DRY auth check
+    
+    // Same patch pattern as existing mutations
+    await ctx.db.patch(args.imageId, {
+      isDisabledByAdmin: false,
+      disabledByAdminAt: undefined,
+      disabledByAdminReason: undefined,
+    });
+    return null;
+  },
+});
+
+export const getAdminFeaturedImages = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+  },
+  returns: PaginatedAdminGalleryValidator,
+  handler: async (ctx, args) => {
+    await assertAdmin(ctx); // DRY auth check
+    
+    // Same query pattern as getPublicGallery
+    const result = await ctx.db
+      .query("images")
+      .withIndex("by_isFeatured_and_featuredAt", (q) => q.eq("isFeatured", true))
+      .order("desc")
+      .paginate(args.paginationOpts);
+
+    // Same batch URL generation pattern
+    const imagesWithUrls = await mapImagesToUrls(ctx, result.page);
+
+    return {
+      page: imagesWithUrls,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,0 +1,20 @@
+export async function requireIdentity(ctx: any) {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error("Not authenticated");
+  return identity;
+}
+
+export async function assertOwner(ctx: any, ownerId: string | undefined) {
+  const identity = await requireIdentity(ctx);
+  if (!ownerId || ownerId !== identity.subject) {
+    throw new Error("Not authorized to modify this image");
+  }
+  return identity;
+}
+
+export async function assertAdmin(ctx: any) {
+  const identity = await requireIdentity(ctx);
+  const isAdmin = identity.publicMetadata?.isAdmin === true;
+  if (!isAdmin) throw new Error("Not authorized - admin only");
+  return identity;
+}

--- a/convex/lib/images.ts
+++ b/convex/lib/images.ts
@@ -1,0 +1,11 @@
+import type { Id } from "../_generated/dataModel";
+
+export async function mapImagesToUrls<T extends { body: Id<"_storage"> }>(
+  ctx: any,
+  docs: Array<T>
+) {
+  const urls = await Promise.all(docs.map((d) => ctx.storage.getUrl(d.body)));
+  return docs
+    .map((d, i) => (urls[i] ? { ...d, url: urls[i] as string } : null))
+    .filter((x): x is T & { url: string } => x !== null);
+}

--- a/convex/lib/validators.ts
+++ b/convex/lib/validators.ts
@@ -1,0 +1,35 @@
+import { v } from "convex/values";
+
+export const GalleryItemValidator = v.object({
+  _id: v.id("images"),
+  _creationTime: v.number(),
+  body: v.id("_storage"),
+  createdAt: v.number(),
+  url: v.string(),
+  userId: v.optional(v.string()),
+  isFeatured: v.optional(v.boolean()),
+});
+
+export const PaginatedGalleryValidator = v.object({
+  page: v.array(GalleryItemValidator),
+  isDone: v.boolean(),
+  continueCursor: v.union(v.string(), v.null()),
+});
+
+export const AdminGalleryItemValidator = v.object({
+  _id: v.id("images"),
+  _creationTime: v.number(),
+  body: v.id("_storage"),
+  createdAt: v.number(),
+  url: v.string(),
+  userId: v.optional(v.string()),
+  isFeatured: v.optional(v.boolean()),
+  isDisabledByAdmin: v.optional(v.boolean()),
+  disabledByAdminReason: v.optional(v.string()),
+});
+
+export const PaginatedAdminGalleryValidator = v.object({
+  page: v.array(AdminGalleryItemValidator),
+  isDone: v.boolean(),
+  continueCursor: v.union(v.string(), v.null()),
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -17,12 +17,27 @@ export default defineSchema({
     ),
     generationError: v.optional(v.string()),
     generationAttempts: v.optional(v.number()), // counts auto/manual attempts
-    // New fields for sharing
+    // Fields for sharing
     sharingEnabled: v.optional(v.boolean()),
     shareExpiresAt: v.optional(v.number()),
+    // Fields for user tracking and public gallery
+    userId: v.optional(v.string()), // Track Clerk user ID who uploaded the image
+    isFeatured: v.optional(v.boolean()), // Simple toggle for public gallery
+    featuredAt: v.optional(v.number()), // Timestamp when marked as featured
+    isDisabledByAdmin: v.optional(v.boolean()), // Admin can disable inappropriate featured images
+    disabledByAdminAt: v.optional(v.number()), // Timestamp when disabled by admin
+    disabledByAdminReason: v.optional(v.string()), // Reason for admin disable
   })
     .index("by_is_generated", ["isGenerated"])
     .index("by_generation_status", ["generationStatus"])
     .index("by_is_generated_and_status", ["isGenerated", "generationStatus"]) // Compound index for filtering
-    .index("by_sharing_enabled", ["sharingEnabled"]),
+    .index("by_sharing_enabled", ["sharingEnabled"])
+    // New indexes for public gallery functionality
+    .index("by_userId", ["userId"]) // Find images by user
+    .index("by_isFeatured", ["isFeatured"]) // Find featured images
+    .index("by_isFeatured_and_featuredAt", ["isFeatured", "featuredAt"]) // Featured images by date
+    .index(
+      "by_isFeatured_and_isDisabledByAdmin_and_featuredAt",
+      ["isFeatured", "isDisabledByAdmin", "featuredAt"]
+    ), // Public query: eq featured + eq not disabled + order by featuredAt
 });


### PR DESCRIPTION
Add an unauthenticated public gallery to showcase user-generated images and improve new user conversion.

---
<a href="https://cursor.com/background-agent?bcId=bc-363fcb2b-1b9a-4be8-8906-6a00118cb0b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-363fcb2b-1b9a-4be8-8906-6a00118cb0b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

